### PR TITLE
Fix typo in examples/utils_ner.py

### DIFF
--- a/examples/utils_ner.py
+++ b/examples/utils_ner.py
@@ -73,7 +73,7 @@ def read_examples_from_file(data_dir, mode):
                     # Examples could have no label for mode = "test"
                     labels.append("O")
         if words:
-            examples.append(InputExample(guid="%s-%d".format(mode, guid_index), words=words, labels=labels))
+            examples.append(InputExample(guid="{}-{}".format(mode, guid_index), words=words, labels=labels))
     return examples
 
 


### PR DESCRIPTION
`"%s-%d".format()` -> `"{}-{}".format()`